### PR TITLE
fix compile warning: catch all Throwables

### DIFF
--- a/scalalib/src/main/scala/SRAM.scala
+++ b/scalalib/src/main/scala/SRAM.scala
@@ -52,7 +52,7 @@ object SRAMMacro {
       case _ => return None
     }
     val depth: BigInt = json.get("depth") match {
-      case Some(x: JsString) => try { BigInt(x.as[String]) } catch { case _ => return None }
+      case Some(x: JsString) => try { BigInt(x.as[String]) } catch { case _: Throwable => return None }
       case _ => return None
     }
     val family: String = json.get("family") match {


### PR DESCRIPTION
**Type of change**: paying off technical debt

**Impact**: no functional change

**What was changed**
fix compile warnings:
```
[warn] /barstools/mdf/scalalib/src/main/scala/SRAM.scala:55:75: This catches all Throwables. If this is really intended, use `case _ : Throwable` to clear this warning.
[warn]       case Some(x: JsString) => try { BigInt(x.as[String]) } catch { case _ => return None }
[warn]                                                                           ^
```