### PR TITLE
Fixed Scala 2.13 stuff.

### DIFF
--- a/src/main/scala/mdf/macrolib/FlipChipMacro.scala
+++ b/src/main/scala/mdf/macrolib/FlipChipMacro.scala
@@ -54,13 +54,13 @@ object FlipChipMacro {
 
     val bumpDimensions: (Int, Int) = json.get("bump_dimensions") match {
       case Some(JsArray(x)) if x.size == 2 =>
-        val z = x.map(_.as[JsNumber].value.intValue())
+        val z = x.map(_.as[JsNumber].value.intValue)
         (z(0), z(1))
       case None => return None
     }
     val bumpLocations: Seq[Seq[String]] = json.get("bump_locations") match {
       case Some(JsArray(array)) =>
-        array.collect { case JsArray(a2) => a2.map(_.toString) }
+        array.collect { case JsArray(a2) => a2.map(_.toString).toSeq }.toSeq
       case _ => return None
     }
     // Can't have dimensions and locations which don't match


### PR DESCRIPTION
intValue does not take parens
added a couple of .toSeq where necessary